### PR TITLE
We can't swap sets that are setup for reading or writing

### DIFF
--- a/radial_sky_rays/radial_sky_rays.gd
+++ b/radial_sky_rays/radial_sky_rays.gd
@@ -269,9 +269,11 @@ func _render_callback(p_effect_callback_type, p_render_data):
 					##############################################################
 					# Step 3: Apply gaussian blur
 
+					# Read from texture image
 					uniform = get_image_uniform(texture_image)
 					texture_uniform_set = UniformSetCacheRD.get_cache(gaussian_blur_shader, 0, [ uniform ])
 
+					# Write to pong texture image
 					uniform = get_image_uniform(pong_texture_image)
 					pong_texture_uniform_set = UniformSetCacheRD.get_cache(gaussian_blur_shader, 1, [ uniform ])
 
@@ -304,6 +306,14 @@ func _render_callback(p_effect_callback_type, p_render_data):
 					push_constant.push_back(gaussian_blur_size)
 
 					rd.draw_command_begin_label("Apply vertical gaussian blur " + str(view), Color(1.0, 1.0, 1.0, 1.0))
+
+					# Read from pong texture image
+					uniform = get_image_uniform(pong_texture_image)
+					pong_texture_uniform_set = UniformSetCacheRD.get_cache(gaussian_blur_shader, 0, [ uniform ])
+
+					# Write to texture image
+					uniform = get_image_uniform(texture_image)
+					texture_uniform_set = UniformSetCacheRD.get_cache(gaussian_blur_shader, 1, [ uniform ])
 
 					compute_list = rd.compute_list_begin()
 					rd.compute_list_bind_compute_pipeline(compute_list, gaussian_blur_pipeline)


### PR DESCRIPTION
So the original code thought to be smart.

For our gaussian blur we're reading from `texture_image`, then writing to `pong_texture_image`, and then in the next call we're flipping them. We were reusing the uniforms we created and just swapping them.

Thing is, a uniform setup for reading shouldn't be used for writing and visa versa, some GPUs are ok with it and just ignore it, but others will fall over.

In Godot 4.5 we started checking for this discrepancy, hence the errors.

Fixes #6